### PR TITLE
Remove geojson dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# 1.1.0 (2020-01-03)
+- Added new UTM5kmTiling tilescheme which aligns to the Maxar Analysis
+  Ready Data (ARD) grid.
+
+# 1.0.0 (2019-08-14)
+- Added new UTM10kmTiling and UTM100kmTiling tile schemes. This
+  provides MGRS-like tilings at a particular zoom level in the
+  quadtree.
+- Added multi zoom level capacity. Now you can pass several zoom
+  levels to cover_geometry and it will generate the biggest tiles
+  availables using those zoom levels. Example:
+
+        tilecover.cover_geometry(tiler, geom, [16, 17, 19])
+
+- Tiletanic now requires python >= 3.6
+
+# 0.0.5 (2016-04-20)
+- Added new tilecover CLI.  To learn more, run
+
+        tiletanic cover-geometry --help
+
+# 0.0.4 (2015-11-07)
+- Added new WebMercator tile scheme
+
+# 0.0.3 (2015-11-04)
+- Initial Release with DGTiling tile scheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Next
+- Remove geojson dependency
+
 # 1.1.0 (2020-01-03)
 - Added new UTM5kmTiling tilescheme which aligns to the Maxar Analysis
   Ready Data (ARD) grid.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 click
-geojson
 pytest>=5.0
 Shapely>=1.6

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(name='tiletanic',
       include_package_data=True,
       zip_safe=False,
       install_requires=['click',
-                        'geojson',
                         'shapely>=1.6'],
       entry_points='''
          [console_scripts]

--- a/tiletanic/cli.py
+++ b/tiletanic/cli.py
@@ -3,7 +3,7 @@
 # Add documentation - how to run with a file vs stdout, document arguments, etc.
 
 import click
-import geojson
+import json
 from shapely import geometry, ops, prepared
 import tiletanic
 
@@ -74,7 +74,7 @@ def cover_geometry(tilescheme, aoi_geojson, zoom, adjacent, quadkey):
     else:
         raise ValueError("tilescheme '{}' is unsupported.").format(tilescheme)
 
-    aoi = geojson.loads( aoi_geojson.read() )
+    aoi = json.loads( aoi_geojson.read() )
 
     if 'type' not in aoi:
         raise ValueError("The 'AOI_GEOJSON' doesn't have a 'type' member. Is it valid GeoJSON?")


### PR DESCRIPTION
Adds a changelog and implements #8: replace [geojson dependency](https://github.com/jazzband/geojson) with [Python json](https://docs.python.org/3/library/json.html)